### PR TITLE
Fix deprecation problem

### DIFF
--- a/ddeint/ddeint.py
+++ b/ddeint/ddeint.py
@@ -142,4 +142,4 @@ def ddeint(func, g, tt, fargs=None):
     dde_.set_initial_value(ddeVar(g, tt[0]))
     dde_.set_f_params(fargs if fargs else [])
     results = [dde_.integrate(dde_.t + dt) for dt in np.diff(tt)]
-    return np.array([g(tt[0])] + results)
+    return np.concatenate([[[g(tt[0])]], results])

--- a/ddeint/ddeint.py
+++ b/ddeint/ddeint.py
@@ -142,4 +142,6 @@ def ddeint(func, g, tt, fargs=None):
     dde_.set_initial_value(ddeVar(g, tt[0]))
     dde_.set_f_params(fargs if fargs else [])
     results = [dde_.integrate(dde_.t + dt) for dt in np.diff(tt)]
-    return np.concatenate([[[g(tt[0])]], results])
+    initial_value = g(tt[0]) if isinstance(g(tt[0]), (list, tuple, np.ndarray)) else np.array([g(tt[0])])
+    results.insert(0, initial_value)
+    return np.stack(results)


### PR DESCRIPTION
Arrays need to be concatenated differently now (Python 3.9). Im not sure which is faster 1. inserting the historical value into the result list and then just returning the result as an array or 2. First converting the historical result to a np.array and then concatenating the current results with the historical first value.

Not yet tested for 2D ODEs.