### PR TITLE
Fix deprecation warning and array dtype problems

### DIFF
--- a/ddeint/ddeint.py
+++ b/ddeint/ddeint.py
@@ -142,4 +142,4 @@ def ddeint(func, g, tt, fargs=None):
     dde_.set_initial_value(ddeVar(g, tt[0]))
     dde_.set_f_params(fargs if fargs else [])
     results = [dde_.integrate(dde_.t + dt) for dt in np.diff(tt)]
-    return np.array([g(tt[0])] + results)
+    return np.append(g(tt[0]), results)


### PR DESCRIPTION
The original code used the `+` operator to join the initial value and the integration resuslts. This led to incorrect array shapes and numpy treating the data inside as dtype=object. Thus scipy interp1d did not work directly with the output of ddeint.

Tested with:
1D DDE (provided examples and own models)

Not tested with:
Systems of DDEs